### PR TITLE
Make compatible with io.js

### DIFF
--- a/nan.h
+++ b/nan.h
@@ -500,10 +500,17 @@ NAN_INLINE v8::Local<T> _NanEnsureLocal(v8::Local<T> val) {
     return v8::String::NewExternal(v8::Isolate::GetCurrent(), resource);
   }
 
+#if NODE_MODULE_VERSION >= 42  // io.js v1.0.0
+  NAN_INLINE v8::Local<v8::String> NanNew(
+      v8::String::ExternalOneByteStringResource *resource) {
+    return v8::String::NewExternal(v8::Isolate::GetCurrent(), resource);
+  }
+#else
   NAN_INLINE v8::Local<v8::String> NanNew(
       v8::String::ExternalAsciiStringResource *resource) {
     return v8::String::NewExternal(v8::Isolate::GetCurrent(), resource);
   }
+#endif
 
 # define NanScope() v8::HandleScope scope(v8::Isolate::GetCurrent())
 # define NanEscapableScope()                                                   \
@@ -2181,14 +2188,25 @@ static bool _NanGetExternalParts(
   assert(val->IsString());
   v8::Local<v8::String> str = NanNew(val.As<v8::String>());
 
+#if NODE_MODULE_VERSION >= 42  // io.js v1.0.0
+  if (str->IsExternalOneByte()) {
+    const v8::String::ExternalOneByteStringResource* ext;
+    ext = str->GetExternalOneByteStringResource();
+    *data = ext->data();
+    *len = ext->length();
+    return true;
+  }
+#else
   if (str->IsExternalAscii()) {
     const v8::String::ExternalAsciiStringResource* ext;
     ext = str->GetExternalAsciiStringResource();
     *data = ext->data();
     *len = ext->length();
     return true;
+  }
+#endif
 
-  } else if (str->IsExternal()) {
+  if (str->IsExternal()) {
     const v8::String::ExternalStringResource* ext;
     ext = str->GetExternalStringResource();
     *data = reinterpret_cast<const char*>(ext->data());

--- a/test/cpp/morenews.cpp
+++ b/test/cpp/morenews.cpp
@@ -52,7 +52,11 @@ class ExtString : public v8::String::ExternalStringResource {
 };
 
 
+#if NODE_VERSION_AT_LEAST(1, 0, 0)
+class ExtAsciiString : public v8::String::ExternalOneByteStringResource {
+#else
 class ExtAsciiString : public v8::String::ExternalAsciiStringResource {
+#endif
  public:
   ~ExtAsciiString() { }
   const char *data() const { return s; }


### PR DESCRIPTION
io.js ships a newer V8 version where String::ExternalAsciiStringResource
has been replaced with String::ExternalOneByteStringResource.

Use SFINAE to make nan compatible with a range of V8 versions.

Fixes #222.

R=@kkoopa