### PR TITLE
Make compatible with io.js

### DIFF
--- a/nan.h
+++ b/nan.h
@@ -1727,14 +1727,25 @@ static bool _NanGetExternalParts(
   assert(val->IsString());
   v8::Local<v8::String> str = NanNew(val.As<v8::String>());
 
+#if NODE_MODULE_VERSION >= 42  // io.js v1.0.0
+  if (str->IsExternalOneByte()) {
+    const v8::String::ExternalOneByteStringResource* ext;
+    ext = str->GetExternalOneByteStringResource();
+    *data = ext->data();
+    *len = ext->length();
+    return true;
+  }
+#else
   if (str->IsExternalAscii()) {
     const v8::String::ExternalAsciiStringResource* ext;
     ext = str->GetExternalAsciiStringResource();
     *data = ext->data();
     *len = ext->length();
     return true;
+  }
+#endif
 
-  } else if (str->IsExternal()) {
+  if (str->IsExternal()) {
     const v8::String::ExternalStringResource* ext;
     ext = str->GetExternalStringResource();
     *data = reinterpret_cast<const char*>(ext->data());

--- a/nan_implementation_12_inl.h
+++ b/nan_implementation_12_inl.h
@@ -179,7 +179,11 @@ Factory<v8::String>::New(v8::String::ExternalStringResource * value) {
 }
 
 Factory<v8::String>::return_t
+#if NODE_MODULE_VERSION >= 42  // io.js v1.0.0
+Factory<v8::String>::New(v8::String::ExternalOneByteStringResource * value) {
+#else
 Factory<v8::String>::New(v8::String::ExternalAsciiStringResource * value) {
+#endif
   return v8::String::NewExternal(v8::Isolate::GetCurrent(), value);
 }
 

--- a/nan_new.h
+++ b/nan_new.h
@@ -132,7 +132,11 @@ struct Factory<v8::String> : FactoryBase<v8::String> {
   static inline return_t New(std::string const& value);
 
   static inline return_t New(v8::String::ExternalStringResource * value);
+#if NODE_MODULE_VERSION >= 42  // io.js v1.0.0
+  static inline return_t New(v8::String::ExternalOneByteStringResource * value);
+#else
   static inline return_t New(v8::String::ExternalAsciiStringResource * value);
+#endif
 
   // TODO(agnat): Deprecate.
   static inline return_t New(const uint8_t * value, int length = -1);
@@ -259,7 +263,11 @@ NanNew(v8::String::ExternalStringResource * value) {
 
 inline
 NanIntern::Factory<v8::String>::return_t
+#if NODE_MODULE_VERSION >= 42  // io.js v1.0.0
+NanNew(v8::String::ExternalOneByteStringResource * value) {
+#else
 NanNew(v8::String::ExternalAsciiStringResource * value) {
+#endif
   return NanNew<v8::String>(value);
 }
 

--- a/test/cpp/morenews.cpp
+++ b/test/cpp/morenews.cpp
@@ -52,7 +52,11 @@ class ExtString : public v8::String::ExternalStringResource {
 };
 
 
+#if NODE_MODULE_VERSION >= 42  // io.js v1.0.0
+class ExtAsciiString : public v8::String::ExternalOneByteStringResource {
+#else
 class ExtAsciiString : public v8::String::ExternalAsciiStringResource {
+#endif
  public:
   ~ExtAsciiString() { }
   const char *data() const { return s; }


### PR DESCRIPTION
io.js ships a newer V8 version where String::ExternalAsciiStringResource
has been replaced with String::ExternalOneByteStringResource.

This change makes nan compile again with V8 3.29 and up.

Fixes #222.

R=@kkoopa @rvagg