### PR TITLE
Make compatible with io.js

### DIFF
--- a/test/cpp/morenews.cpp
+++ b/test/cpp/morenews.cpp
@@ -52,7 +52,11 @@ class ExtString : public v8::String::ExternalStringResource {
 };
 
 
+#if NODE_MODULE_VERSION >= 42  // io.js v1.0.0
+class ExtAsciiString : public v8::String::ExternalOneByteStringResource {
+#else
 class ExtAsciiString : public v8::String::ExternalAsciiStringResource {
+#endif
  public:
   ~ExtAsciiString() { }
   const char *data() const { return s; }


### PR DESCRIPTION
io.js ships a newer V8 version where String::ExternalAsciiStringResource
has been replaced with String::ExternalOneByteStringResource.

This change makes nan compile again with V8 3.29 and up.

Fixes #222.

This is a back-port of commit b003843 from the 1.5 and master branch
and should make modules that depend on nan ~1.4.x work with io.js
without requiring action from their maintainers.

Apologies, I had to create a v1.4 branch (branched off the v1.4.1 tag) to base this PR against.