### PR TITLE
Fix non-inline definition build error with clang++

### DIFF
--- a/nan_implementation_12_inl.h
+++ b/nan_implementation_12_inl.h
@@ -214,14 +214,12 @@ Factory<v8::UnboundScript>::New( v8::Local<v8::String> source
 //=== Presistents and Handles ==================================================
 
 template <typename T>
-v8::Local<T>
-NanNew(v8::Handle<T> h) {
+inline v8::Local<T> NanNew(v8::Handle<T> h) {
   return v8::Local<T>::New(v8::Isolate::GetCurrent(), h);
 }
 
 template <typename T>
-v8::Local<T>
-NanNew(v8::Persistent<T> const& p) {
+inline v8::Local<T> NanNew(v8::Persistent<T> const& p) {
   return v8::Local<T>::New(v8::Isolate::GetCurrent(), p);
 }
 


### PR DESCRIPTION
Fix the following build error when building with clang++:

    In file included from ../cpp/asyncprogressworker.cpp:13:
    In file included from ../../nan.h:63:
    ../../nan_new.h:207:43: error: inline declaration of 'NanNew' follows non-inline definition
    template <typename T> inline v8::Local<T> NanNew(v8::Handle<T> h);
                                              ^
    ../../nan_implementation_12_inl.h:218:1: note: previous definition is here
    NanNew(v8::Handle<T> h) {
    ^
    In file included from ../cpp/asyncprogressworker.cpp:13:
    In file included from ../../nan.h:63:
    ../../nan_new.h:208:43: error: inline declaration of 'NanNew' follows non-inline definition
    template <typename T> inline v8::Local<T> NanNew(v8::Persistent<T> const& p);
                                              ^
    ../../nan_implementation_12_inl.h:224:1: note: previous definition is here
    NanNew(v8::Persistent<T> const& p) {

g++ is more lenient but clang++ is not wrong to complain.

Fixes: https://github.com/rvagg/nan/issues/231

R=@kkoopa