### PR TITLE
Fix non-inline definition build error with clang++

### DIFF
--- a/nan_implementation_pre_12_inl.h
+++ b/nan_implementation_pre_12_inl.h
@@ -206,14 +206,12 @@ Factory<v8::StringObject>::New(v8::Handle<v8::String> value) {
 //=== Presistents and Handles ==================================================
 
 template <typename T>
-v8::Local<T>
-NanNew(v8::Handle<T> h) {
+inline v8::Local<T> NanNew(v8::Handle<T> h) {
   return v8::Local<T>::New(h);
 }
 
 template <typename T>
-v8::Local<T>
-NanNew(v8::Persistent<T> const& p) {
+inline v8::Local<T> NanNew(v8::Persistent<T> const& p) {
   return v8::Local<T>::New(p);
 }
 


### PR DESCRIPTION
Fix the following build error when building with clang++:

    In file included from ../cpp/asyncprogressworker.cpp:13:
    In file included from ../../nan.h:63:
    ../../nan_new.h:207:43: error: inline declaration of 'NanNew' follows non-inline definition
    template <typename T> inline v8::Local<T> NanNew(v8::Handle<T> h);
                                              ^
    ../../nan_implementation_pre_12_inl.h:210:1: note: previous definition is here
    NanNew(v8::Handle<T> h) {
    ^
    In file included from ../cpp/asyncprogressworker.cpp:13:
    In file included from ../../nan.h:63:
    ../../nan_new.h:208:43: error: inline declaration of 'NanNew' follows non-inline definition
    template <typename T> inline v8::Local<T> NanNew(v8::Persistent<T> const& p);
                                              ^
    ../../nan_implementation_pre_12_inl.h:216:1: note: previous definition is here
    NanNew(v8::Persistent<T> const& p) {
    ^
    2 errors generated.

g++ is more lenient but clang++ is not wrong to complain.

Fixes: https://github.com/rvagg/nan/issues/231 (for v0.10 this time.)

R=@kkoopa

Mea culpa, I could swear I tested with v0.10 as well.