### PR TITLE
Readded missing String constructors.

### DIFF
--- a/nan_implementation_12_inl.h
+++ b/nan_implementation_12_inl.h
@@ -150,6 +150,11 @@ Factory<v8::Signature>::New( Factory<v8::Signature>::FTH receiver
 //=== String ===================================================================
 
 Factory<v8::String>::return_t
+Factory<v8::String>::New() {
+  return v8::String::Empty(v8::Isolate::GetCurrent());
+}
+
+Factory<v8::String>::return_t
 Factory<v8::String>::New(const char * value, int length) {
   return v8::String::NewFromUtf8(v8::Isolate::GetCurrent(), value,
       v8::String::kNormalString, length);

--- a/nan_implementation_pre_12_inl.h
+++ b/nan_implementation_pre_12_inl.h
@@ -147,6 +147,11 @@ Factory<v8::Signature>::New( Factory<v8::Signature>::FTH receiver
 //=== String ===================================================================
 
 Factory<v8::String>::return_t
+Factory<v8::String>::New() {
+  return v8::String::Empty();
+}
+
+Factory<v8::String>::return_t
 Factory<v8::String>::New(const char * value, int length) {
   return v8::String::New(value, length);
 }

--- a/nan_new.h
+++ b/nan_new.h
@@ -127,6 +127,7 @@ struct Factory<v8::Signature> : FactoryBase<v8::Signature> {
 
 template <>
 struct Factory<v8::String> : FactoryBase<v8::String> {
+  static inline return_t New();
   static inline return_t New(const char *value, int length = -1);
   static inline return_t New(const uint16_t *value, int length = -1);
   static inline return_t New(std::string const& value);
@@ -235,6 +236,12 @@ inline
 NanIntern::Factory<v8::String>::return_t
 NanNew(std::string const& value) {
   return NanNew<v8::String>(value);
+}
+
+inline
+NanIntern::Factory<v8::String>::return_t
+NanNew(const char * value, int length) {
+  return NanNew<v8::String>(value, length);
 }
 
 inline

--- a/test/cpp/nannew.cpp
+++ b/test/cpp/nannew.cpp
@@ -231,12 +231,15 @@ NAN_METHOD(testString) {
   NanScope();
   NanTap t(args[0]);
 
-  t.plan(10);
+  t.plan(14);
 
   t.ok(_( stringMatches( NanNew<String>("Hello World"), "Hello World")));
   t.ok(_( stringMatches( NanNew<String>("Hello World", 4), "Hell")));
   t.ok(_( stringMatches( NanNew<String>(std::string("foo")), "foo")));
   t.ok(_( assertType<String>( NanNew<String>("plonk."))));
+
+  t.ok(_( stringMatches( NanNew<String>(), "")));
+  t.ok(_( assertType<String>( NanNew<String>())));
 
   // These should be deprecated
   const uint8_t *ustring = reinterpret_cast<const uint8_t *>("unsigned chars");
@@ -248,6 +251,9 @@ NAN_METHOD(testString) {
   t.ok(_( stringMatches( NanNew("using namespace nan; // is poetry"),
           "using namespace nan; // is poetry")));
   t.ok(_( assertType<String>( NanNew("plonk."))));
+
+  t.ok(_( stringMatches( NanNew("Hello World", 4), "Hell")));
+  t.ok(_( assertType<String>( NanNew("plonk.", 4))));
 
   t.ok(_( stringMatches( NanNew(std::string("bar")), "bar")));
   t.ok(_( assertType<String>( NanNew(std::string("plonk.")))));


### PR DESCRIPTION
Added `String` constructors that were inadvertently omitted in the `NanNew` rewrite.
Fixes #227.

R=@agnat