### PR TITLE
NAN 1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # NAN ChangeLog
 
-**Version 1.5.2: current Node unstable: 0.11.15, Node stable: 0.10.35, io.js: 1.0.3**
+**Version 1.6.0: current Node unstable: 0.11.15, Node stable: 0.10.35, io.js: 1.0.3**
+
+### 1.6.0 Jan 23 2015
+ - Deprecated `NanNewContextHandle` in favor of `NanNew<Context>` 49259af
+ - Support utility functions moved in newer v8 versions (Node 0.11.15, io.js 1.0) a0aa179
+ - Added `NanEncode`, `NanDecodeBytes` and `NanDecodeWrite` 75e6fb9
 
 ### 1.5.2 Jan 23 2015
 
@@ -13,7 +18,6 @@
   - Correctness: Lifted an io.js related typedef c9490be
   - Correctness: Make explicit downcasts of String lengths 00074e6
   - Windows: Limit the scope of disabled warning C4530 83d7deb
-
 
 ### 1.5.1 Jan 15 2015
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Native Abstractions for Node.js
 
 **A header file filled with macro and utility goodness for making add-on development for Node.js easier across versions 0.8, 0.10 and 0.11, and eventually 0.12.**
 
-***Current version: 1.5.2***
+***Current version: 1.6.0***
 
 *(See [CHANGELOG.md](https://github.com/rvagg/nan/blob/master/CHANGELOG.md) for complete ChangeLog)*
 
@@ -24,6 +24,13 @@ This project also contains some helper utilities that make addon development a b
 
 <a name="news"></a>
 ## News & Updates
+
+### Jan-2015: 1.6.0 release
+
+* Deprecated `NanNewContextHandle` in favor of `NanNew<Context>`
+* Added `NanSetCounterFunction`, `NanSetCreateHistogramFunction`, `NanSetAddHistogramSampleFunction`
+* Added `NanIdleNotification`, `NanLowMemoryNotification`, `NanContextDisposedNotification`
+* Added `NanEncode`, `NanDecodeBytes` and `NanDecodeWrite`
 
 ### Jan-2015: 1.5.0 release
 

--- a/README.md
+++ b/README.md
@@ -302,6 +302,12 @@ NAN_METHOD(CalculateAsync) {
  * <a href="#api_nan_remove_gc_epilogue_callback"><b><code>NanRemoveGCEpilogueCallback</code></b></a>
  * <a href="#api_nan_remove_gc_prologue_callback"><b><code>NanRemoveGCPrologueCallback</code></b></a>
  * <a href="#api_nan_get_heap_statistics"><b><code>NanGetHeapStatistics</code></b></a>
+ * <a href="#api_nan_set_counter_function"><b><code>NanSetCounterFunction</code></b></a>
+ * <a href="#api_nan_set_create_histogram_function"><b><code>NanSetCreateHistogramFunction</code></b></a>
+ * <a href="#api_nan_set_add_histogram_sample_function"><b><code>NanSetAddHistogramSampleFunction</code></b></a>
+ * <a href="#api_nan_idle_notification"><b><code>NanIdleNotification</code></b></a>
+ * <a href="#api_nan_low_memory_notification"><b><code>NanLowMemoryNotification</code></b></a>
+ * <a href="#api_nan_context_disposed_notification"><b><code>NanContextDisposedNotification</code></b></a>
  * <a href="#api_nan_callback"><b><code>NanCallback</code></b></a>
  * <a href="#api_nan_async_worker"><b><code>NanAsyncWorker</code></b></a>
  * <a href="#api_nan_async_queue_worker"><b><code>NanAsyncQueueWorker</code></b></a>
@@ -1097,6 +1103,36 @@ Simply does `RemoveGCPrologueCallback`
 ### NanGetHeapStatistics(HeapStatistics *heap_statistics)
 
 Simply does `GetHeapStatistics`
+
+<a name="api_nan_set_counter_function"></a>
+### NanSetCounterFunction(CounterLookupCallback cb)
+
+Simply does `SetCounterFunction`
+
+<a name="api_nan_set_create_histogram_function"></a>
+### NanSetCreateHistogramFunction(CreateHistogramCallback cb)
+
+Simply does `SetCreateHistogramFunction`
+
+<a name="api_nan_set_add_histogram_sample_function"></a>
+### NanSetAddHistogramSampleFunction(AddHistogramSampleCallback cb)
+
+Simply does `SetAddHistogramSampleFunction`
+
+<a name="api_nan_idle_notification"></a>
+### NanIdleNotification(int idle_time_in_ms)
+
+Simply does `IdleNotification`
+
+<a name="api_nan_low_memory_notification"></a>
+### NanLowMemoryNotification()
+
+Simply does `LowMemoryNotification`
+
+<a name="api_nan_context_disposed_notification"></a>
+### NanContextDisposedNotification()
+
+Simply does `ContextDisposedNotification`
 
 <a name="api_nan_callback"></a>
 ### NanCallback

--- a/README.md
+++ b/README.md
@@ -294,6 +294,9 @@ NAN_METHOD(CalculateAsync) {
  * <a href="#api_nan_set_prototype_template"><b><code>NanSetPrototypeTemplate</code></b></a>
  * <a href="#api_nan_set_instance_template"><b><code>NanSetInstanceTemplate</code></b></a>
  * <a href="#api_nan_make_callback"><b><code>NanMakeCallback</code></b></a>
+ * <a href="#api_nan_encode"><b><code>NanEncode</code></b></a>
+ * <a href="#api_nan_decode_bytes"><b><code>NanDecodeBytes</code></b></a>
+ * <a href="#api_nan_decode_write"><b><code>NanDecodeWrite</code></b></a>
  * <a href="#api_nan_compile_script"><b><code>NanCompileScript</code></b></a>
  * <a href="#api_nan_run_script"><b><code>NanRunScript</code></b></a>
  * <a href="#api_nan_adjust_external_memory"><b><code>NanAdjustExternalMemory</code></b></a>
@@ -1066,6 +1069,21 @@ Use to add instance properties on function templates.
 ### NanMakeCallback(target, func, argc, argv)
 
 Use instead of `node::MakeCallback` to call javascript functions. This (or `NanCallback`) is the only proper way of calling functions. You must _*never, ever*_ directly use `Function::Call`, it will lead to run-time failures.
+
+<a name="api_nan_encode"></a>
+### NanEncode(const void*, size_t[, enum Nan::Encoding])
+
+Replaces `node::Encode`.
+
+<a name="api_nan_decode_bytes"></a>
+### NanDecodeBytes(v8::Handle&lt;v8::Value&gt;[, enum Nan::Encoding])
+
+Replaces `node::DecodeBytes`.
+
+<a name="api_nan_decode_write"></a>
+### NanDecodeWrite(char *, size_t, v8::Handle&lt;v8::Value&gt;[, enum Nan::Encoding])
+
+Replaces `node::DecodeWrite`.
 
 <a name="api_nan_compile_script"></a>
 ### NanCompileScript(Handle<String> s [, const ScriptOrigin&amp; origin])

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ NAN_METHOD(CalculateAsync) {
  * <a href="#api_nan_throw_error"><b><code>NanThrowError</code></b>, <b><code>NanThrowTypeError</code></b>, <b><code>NanThrowRangeError</code></b>, <b><code>NanThrowError(Handle<Value>)</code></b>, <b><code>NanThrowError(Handle<Value>, int)</code></b></a>
  * <a href="#api_nan_new_buffer_handle"><b><code>NanNewBufferHandle(char *, size_t, FreeCallback, void *)</code></b>, <b><code>NanNewBufferHandle(char *, uint32_t)</code></b>, <b><code>NanNewBufferHandle(uint32_t)</code></b></a>
  * <a href="#api_nan_buffer_use"><b><code>NanBufferUse(char *, uint32_t)</code></b></a>
- * <a href="#api_nan_new_context_handle"><b><code>NanNewContextHandle</code></b></a>
+ * <del><a href="#api_nan_new_context_handle"><b><code>NanNewContextHandle</code></b></a></del>
  * <a href="#api_nan_get_current_context"><b><code>NanGetCurrentContext</code></b></a>
  * <a href="#api_nan_has_instance"><b><code>NanHasInstance</code></b></a>
  * <a href="#api_nan_dispose_persistent"><b><code>NanDisposePersistent</code></b></a>
@@ -980,8 +980,11 @@ careless use can lead to "double free or corruption" and other cryptic failures.
 Can be used to check the type of an object to determine it is of a particular class you have already defined and have a `Persistent<FunctionTemplate>` handle for.
 
 <a name="api_nan_new_context_handle"></a>
-### Local&lt;Context&gt; NanNewContextHandle([ExtensionConfiguration*, Handle&lt;ObjectTemplate&gt;, Handle&lt;Value&gt;])
-Creates a new `Local<Context>` handle.
+### ~~Local&lt;Context&gt; NanNewContextHandle([ExtensionConfiguration*, Handle&lt;ObjectTemplate&gt;, Handle&lt;Value&gt;])
+
+Deprecated. Use `NanNew<Context>` instead.
+
+~~Creates a new `Local<Context>` handle.
 
 ```c++
 Local<FunctionTemplate> ftmpl = NanNew<FunctionTemplate>();

--- a/nan.h
+++ b/nan.h
@@ -12,7 +12,7 @@
  *
  * MIT License <https://github.com/rvagg/nan/blob/master/LICENSE.md>
  *
- * Version 1.5.2: current Node unstable: 0.11.15, Node stable: 0.10.35, io.js: 1.0.3
+ * Version 1.6.0: current Node unstable: 0.11.15, Node stable: 0.10.35, io.js: 1.0.3
  *
  * See https://github.com/rvagg/nan for the latest update to this file
  **********************************************************************************/

--- a/nan.h
+++ b/nan.h
@@ -166,7 +166,8 @@ NAN_INLINE v8::Local<T> _NanEnsureLocal(v8::Local<T> val) {
   return val;
 }
 
-#if NODE_MODULE_VERSION >= 42  // io.js 1.0
+/* io.js 1.0  */
+#if NODE_MODULE_VERSION >= 42 || NODE_VERSION_AT_LEAST(0, 11, 15)
   NAN_INLINE
   void NanSetCounterFunction(v8::CounterLookupCallback cb) {
     v8::Isolate::GetCurrent()->SetCounterFunction(cb);

--- a/nan.h
+++ b/nan.h
@@ -166,7 +166,7 @@ NAN_INLINE v8::Local<T> _NanEnsureLocal(v8::Local<T> val) {
   return val;
 }
 
-#if NODE_MODULE_VERSION >= 42 // io.js 1.0
+#if NODE_MODULE_VERSION >= 42  // io.js 1.0
   NAN_INLINE
   void NanSetCounterFunction(v8::CounterLookupCallback cb) {
     v8::Isolate::GetCurrent()->SetCounterFunction(cb);
@@ -1839,6 +1839,68 @@ static bool _NanGetExternalParts(
 
 namespace Nan {
   enum Encoding {ASCII, UTF8, BASE64, UCS2, BINARY, HEX, BUFFER};
+}
+
+NAN_INLINE v8::Local<v8::Value> NanEncode(
+    const void *buf, size_t len, enum Nan::Encoding encoding = Nan::BINARY) {
+#if (NODE_MODULE_VERSION > 0x000B)
+  return node::Encode(
+      v8::Isolate::GetCurrent()
+    , buf, len
+    , static_cast<node::encoding>(encoding));
+#else
+# if  (NODE_MODULE_VERSION < 0x000B)
+  if (encoding == Nan::BUFFER) {
+    assert(len <= node::Buffer::kMaxLength);
+    return v8::Local<v8::Value>::New(node::Buffer::New(
+        static_cast<char *>(const_cast<void *>(buf)), len)->handle_);
+  }
+# endif
+  return node::Encode(buf, len, static_cast<node::encoding>(encoding));
+#endif
+}
+
+NAN_INLINE ssize_t NanDecodeBytes(
+    v8::Handle<v8::Value> val, enum Nan::Encoding encoding = Nan::BINARY) {
+#if (NODE_MODULE_VERSION > 0x000B)
+  return node::DecodeBytes(
+      v8::Isolate::GetCurrent()
+    , val
+    , static_cast<node::encoding>(encoding));
+#else
+# if (NODE_MODULE_VERSION < 0x000B)
+  if (encoding == Nan::BUFFER) {
+    return node::DecodeBytes(val, node::BINARY);
+  }
+# endif
+  return node::DecodeBytes(val, static_cast<node::encoding>(encoding));
+#endif
+}
+
+NAN_INLINE ssize_t NanDecodeWrite(
+    char *buf
+  , size_t len
+  , v8::Handle<v8::Value> val
+  , enum Nan::Encoding encoding = Nan::BINARY) {
+#if (NODE_MODULE_VERSION > 0x000B)
+  return node::DecodeWrite(
+      v8::Isolate::GetCurrent()
+    , buf
+    , len
+    , val
+    , static_cast<node::encoding>(encoding));
+#else
+# if (NODE_MODULE_VERSION < 0x000B)
+  if (encoding == Nan::BUFFER) {
+    return node::DecodeWrite(buf, len, val, node::BINARY);
+  }
+# endif
+  return node::DecodeWrite(
+      buf
+    , len
+    , val
+    , static_cast<node::encoding>(encoding));
+#endif
 }
 
 /* NAN_DEPRECATED */ NAN_INLINE void* _NanRawString(

--- a/nan.h
+++ b/nan.h
@@ -585,7 +585,7 @@ NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
     return NanNew(function_template)->HasInstance(value);
   }
 
-  NAN_INLINE v8::Local<v8::Context> NanNewContextHandle(
+  NAN_DEPRECATED NAN_INLINE v8::Local<v8::Context> NanNewContextHandle(
       v8::ExtensionConfiguration* extensions = NULL
     , v8::Handle<v8::ObjectTemplate> tmpl = v8::Handle<v8::ObjectTemplate>()
     , v8::Handle<v8::Value> obj = v8::Handle<v8::Value>()
@@ -1131,7 +1131,7 @@ NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
     return function_template->HasInstance(value);
   }
 
-  NAN_INLINE v8::Local<v8::Context> NanNewContextHandle(
+  NAN_DEPRECATED NAN_INLINE v8::Local<v8::Context> NanNewContextHandle(
       v8::ExtensionConfiguration* extensions = NULL
     , v8::Handle<v8::ObjectTemplate> tmpl = v8::Handle<v8::ObjectTemplate>()
     , v8::Handle<v8::Value> obj = v8::Handle<v8::Value>()

--- a/nan.h
+++ b/nan.h
@@ -166,6 +166,62 @@ NAN_INLINE v8::Local<T> _NanEnsureLocal(v8::Local<T> val) {
   return val;
 }
 
+#if NODE_MODULE_VERSION >= 42 // io.js 1.0
+  NAN_INLINE
+  void NanSetCounterFunction(v8::CounterLookupCallback cb) {
+    v8::Isolate::GetCurrent()->SetCounterFunction(cb);
+  }
+
+  NAN_INLINE
+  void NanSetCreateHistogramFunction(v8::CreateHistogramCallback cb) {
+    v8::Isolate::GetCurrent()->SetCreateHistogramFunction(cb);
+  }
+
+  NAN_INLINE
+  void NanSetAddHistogramSampleFunction(v8::AddHistogramSampleCallback cb) {
+    v8::Isolate::GetCurrent()->SetAddHistogramSampleFunction(cb);
+  }
+
+  NAN_INLINE bool NanIdleNotification(int idle_time_in_ms) {
+    return v8::Isolate::GetCurrent()->IdleNotification(idle_time_in_ms);
+  }
+
+  NAN_INLINE void NanLowMemoryNotification() {
+    v8::Isolate::GetCurrent()->LowMemoryNotification();
+  }
+
+  NAN_INLINE void NanContextDisposedNotification() {
+    v8::Isolate::GetCurrent()->ContextDisposedNotification();
+  }
+#else
+  NAN_INLINE
+  void NanSetCounterFunction(v8::CounterLookupCallback cb) {
+    v8::V8::SetCounterFunction(cb);
+  }
+
+  NAN_INLINE
+  void NanSetCreateHistogramFunction(v8::CreateHistogramCallback cb) {
+    v8::V8::SetCreateHistogramFunction(cb);
+  }
+
+  NAN_INLINE
+  void NanSetAddHistogramSampleFunction(v8::AddHistogramSampleCallback cb) {
+    v8::V8::SetAddHistogramSampleFunction(cb);
+  }
+
+  NAN_INLINE bool NanIdleNotification(int idle_time_in_ms) {
+    return v8::V8::IdleNotification(idle_time_in_ms);
+  }
+
+  NAN_INLINE void NanLowMemoryNotification() {
+    v8::V8::LowMemoryNotification();
+  }
+
+  NAN_INLINE void NanContextDisposedNotification() {
+    v8::V8::ContextDisposedNotification();
+  }
+#endif
+
 #if (NODE_MODULE_VERSION > 0x000B)
 // Node 0.11+ (0.11.12 and below won't compile with these)
 

--- a/nan_implementation_12_inl.h
+++ b/nan_implementation_12_inl.h
@@ -48,6 +48,15 @@ Factory<v8::BooleanObject>::New(bool value) {
   return v8::BooleanObject::New(value).As<v8::BooleanObject>();
 }
 
+//=== Context ==================================================================
+
+Factory<v8::Context>::return_t
+Factory<v8::Context>::New( v8::ExtensionConfiguration* extensions
+                         , v8::Handle<v8::ObjectTemplate> tmpl
+                         , v8::Handle<v8::Value> obj) {
+  return v8::Context::New(v8::Isolate::GetCurrent(), extensions, tmpl, obj);
+}
+
 //=== Date =====================================================================
 
 Factory<v8::Date>::return_t

--- a/nan_implementation_pre_12_inl.h
+++ b/nan_implementation_pre_12_inl.h
@@ -53,6 +53,18 @@ Factory<v8::BooleanObject>::New(bool value) {
   return v8::BooleanObject::New(value).As<v8::BooleanObject>();
 }
 
+//=== Context ==================================================================
+
+Factory<v8::Context>::return_t
+Factory<v8::Context>::New( v8::ExtensionConfiguration* extensions
+                         , v8::Handle<v8::ObjectTemplate> tmpl
+                         , v8::Handle<v8::Value> obj) {
+  v8::Persistent<v8::Context> ctx = v8::Context::New(extensions, tmpl, obj);
+  v8::Local<v8::Context> lctx = v8::Local<v8::Context>::New(ctx);
+  ctx.Dispose();
+  return lctx;
+}
+
 //=== Date =====================================================================
 
 Factory<v8::Date>::return_t

--- a/nan_new.h
+++ b/nan_new.h
@@ -58,6 +58,15 @@ struct Factory<v8::BooleanObject> : FactoryBase<v8::BooleanObject> {
 };
 
 template <>
+struct Factory<v8::Context> : FactoryBase<v8::Context> {
+  static inline
+  return_t
+  New( v8::ExtensionConfiguration* extensions = NULL
+     , v8::Handle<v8::ObjectTemplate> tmpl = v8::Handle<v8::ObjectTemplate>()
+     , v8::Handle<v8::Value> obj = v8::Handle<v8::Value>());
+};
+
+template <>
 struct Factory<v8::Date> : FactoryBase<v8::Date> {
   static inline return_t New(double value);
 };

--- a/test/cpp/nannew.cpp
+++ b/test/cpp/nannew.cpp
@@ -99,6 +99,23 @@ NAN_METHOD(testBooleanObject) {
 }
 #undef V
 
+NAN_METHOD(testContext) {
+  NanScope();
+  NanTap t(args[0]);
+
+  t.plan(4);
+  t.ok(_( assertType<Context>( NanNew<Context>())));
+  ExtensionConfiguration extensions(0, NULL);
+  t.ok(_( assertType<Context>( NanNew<Context>(&extensions))));
+  t.ok(_( assertType<Context>(
+          NanNew<Context>(&extensions, Handle<ObjectTemplate>()))));
+  t.ok(_( assertType<Context>(
+          NanNew<Context>(&extensions
+          , Handle<ObjectTemplate>(), Handle<Value>()))));
+
+  return_NanUndefined();
+}
+
 NAN_METHOD(testDate) {
   NanScope();
   NanTap t(args[0]);
@@ -446,6 +463,7 @@ void Init(Handle<Object> exports) {
   NAN_EXPORT(exports, testArray);
   NAN_EXPORT(exports, testBoolean);
   NAN_EXPORT(exports, testBooleanObject);
+  NAN_EXPORT(exports, testContext);
   NAN_EXPORT(exports, testDate);
   NAN_EXPORT(exports, testExternal);
   NAN_EXPORT(exports, testFunction);


### PR DESCRIPTION
* Added new functions to deal with functions moved from V8 to Isolate. See #225.
* Deprecated `NanNewContextHandle` in favor of `NanNew<Context>`.
* Add support for node::Encode/DecodeBytes/DecodeWrite