### PR TITLE
Fix #242: Disambiguate function pointer arguments

### DIFF
--- a/nan_new.h
+++ b/nan_new.h
@@ -203,6 +203,14 @@ NanNew(A0 arg0, A1 arg1, A2 arg2, A3 arg3) {
   return NanIntern::Factory<T>::New(arg0, arg1, arg2, arg3);
 }
 
+template <typename T>
+typename NanIntern::Factory<T>::return_t
+NanNew( NanFunctionCallback callback
+      , v8::Handle<v8::Value> data = v8::Handle<v8::Value>()
+      , v8::Handle<v8::Signature> signature = v8::Handle<v8::Signature>()) {
+    return NanIntern::Factory<T>::New(callback, data, signature);
+}
+
 // Convenience
 
 template <typename T> inline v8::Local<T> NanNew(v8::Handle<T> h);

--- a/test/cpp/nannew.cpp
+++ b/test/cpp/nannew.cpp
@@ -328,6 +328,31 @@ NAN_METHOD(testRegression212) {
   return_NanUndefined();
 }
 
+/* Compile time regression test for https://github.com/rvagg/nan/issues/242
+ * In the presence of overloaded functions NaN should be able to pick the one
+ * matching NanFunctionCallback. 
+ */
+void overloaded() {}
+NAN_METHOD(overloaded) {
+    overloaded();  // not unused
+    return_NanUndefined();
+}
+
+NAN_METHOD(testRegression242) {
+  NanScope();
+  NanTap t(args[0]);
+
+  // This line needs to *compile*. Not much to test at runtime.
+  Local<FunctionTemplate> ft = NanNew<FunctionTemplate>(overloaded);
+  (void)ft;  // not unused
+
+  t.plan(1);
+
+  t.ok(true, "compile-time regression test #242");
+
+  return_NanUndefined();
+}
+
 
 //==============================================================================
 // JavaScript Tests
@@ -386,6 +411,7 @@ void Init(Handle<Object> exports) {
   NAN_EXPORT(exports, testPersistents);
 
   NAN_EXPORT(exports, testRegression212);
+  NAN_EXPORT(exports, testRegression242);
 
   NAN_EXPORT(exports, newIntegerWithValue);
   NAN_EXPORT(exports, newNumberWithValue);


### PR DESCRIPTION
This PR fixes #242. Turns out I initially proposed exactly the wrong fix. Using a function template specialization just doesn't work:

1. You can't come up with default arguments for a full specialization. (Kind of obvious)
2. Less obvious: Full specializations are *not* part of the overload set. See http://www.gotw.ca/publications/mill17.htm

So, we need to do the other thing. Instead of using a specialization, like:

````c++
template <>
typename NanIntern::Factory<v8::FunctionTemplate>::return_t
NanNew<v8::FunctionTemplate>(NanFunctionCallback callback) {
    return NanIntern::Factory<v8::FunctionTemplate>::New(callback);
}
````

we're going to use an overload: