### PR TITLE
Context Constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ NAN_METHOD(CalculateAsync) {
  * <a href="#api_nan_throw_error"><b><code>NanThrowError</code></b>, <b><code>NanThrowTypeError</code></b>, <b><code>NanThrowRangeError</code></b>, <b><code>NanThrowError(Handle<Value>)</code></b>, <b><code>NanThrowError(Handle<Value>, int)</code></b></a>
  * <a href="#api_nan_new_buffer_handle"><b><code>NanNewBufferHandle(char *, size_t, FreeCallback, void *)</code></b>, <b><code>NanNewBufferHandle(char *, uint32_t)</code></b>, <b><code>NanNewBufferHandle(uint32_t)</code></b></a>
  * <a href="#api_nan_buffer_use"><b><code>NanBufferUse(char *, uint32_t)</code></b></a>
- * <a href="#api_nan_new_context_handle"><b><code>NanNewContextHandle</code></b></a>
+ * <del><a href="#api_nan_new_context_handle"><b><code>NanNewContextHandle</code></b></a></del>
  * <a href="#api_nan_get_current_context"><b><code>NanGetCurrentContext</code></b></a>
  * <a href="#api_nan_has_instance"><b><code>NanHasInstance</code></b></a>
  * <a href="#api_nan_dispose_persistent"><b><code>NanDisposePersistent</code></b></a>
@@ -973,8 +973,11 @@ careless use can lead to "double free or corruption" and other cryptic failures.
 Can be used to check the type of an object to determine it is of a particular class you have already defined and have a `Persistent<FunctionTemplate>` handle for.
 
 <a name="api_nan_new_context_handle"></a>
-### Local&lt;Context&gt; NanNewContextHandle([ExtensionConfiguration*, Handle&lt;ObjectTemplate&gt;, Handle&lt;Value&gt;])
-Creates a new `Local<Context>` handle.
+### ~~Local&lt;Context&gt; NanNewContextHandle([ExtensionConfiguration*, Handle&lt;ObjectTemplate&gt;, Handle&lt;Value&gt;])
+
+Deprecated. Use `NanNew<Context>` instead.
+
+~~Creates a new `Local<Context>` handle.
 
 ```c++
 Local<FunctionTemplate> ftmpl = NanNew<FunctionTemplate>();

--- a/nan.h
+++ b/nan.h
@@ -518,7 +518,7 @@ NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
     return NanNew(function_template)->HasInstance(value);
   }
 
-  NAN_INLINE v8::Local<v8::Context> NanNewContextHandle(
+  NAN_DEPRECATED NAN_INLINE v8::Local<v8::Context> NanNewContextHandle(
       v8::ExtensionConfiguration* extensions = NULL
     , v8::Handle<v8::ObjectTemplate> tmpl = v8::Handle<v8::ObjectTemplate>()
     , v8::Handle<v8::Value> obj = v8::Handle<v8::Value>()
@@ -1064,7 +1064,7 @@ NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
     return function_template->HasInstance(value);
   }
 
-  NAN_INLINE v8::Local<v8::Context> NanNewContextHandle(
+  NAN_DEPRECATED NAN_INLINE v8::Local<v8::Context> NanNewContextHandle(
       v8::ExtensionConfiguration* extensions = NULL
     , v8::Handle<v8::ObjectTemplate> tmpl = v8::Handle<v8::ObjectTemplate>()
     , v8::Handle<v8::Value> obj = v8::Handle<v8::Value>()

--- a/nan_implementation_12_inl.h
+++ b/nan_implementation_12_inl.h
@@ -42,6 +42,15 @@ Factory<v8::BooleanObject>::New(bool value) {
   return v8::BooleanObject::New(value).As<v8::BooleanObject>();
 }
 
+//=== Context ==================================================================
+
+Factory<v8::Context>::return_t
+Factory<v8::Context>::New( v8::ExtensionConfiguration* extensions
+                         , v8::Handle<v8::ObjectTemplate> tmpl
+                         , v8::Handle<v8::Value> obj) {
+  return v8::Context::New(v8::Isolate::GetCurrent(), extensions, tmpl, obj);
+}
+
 //=== Date =====================================================================
 
 Factory<v8::Date>::return_t

--- a/nan_implementation_pre_12_inl.h
+++ b/nan_implementation_pre_12_inl.h
@@ -45,6 +45,18 @@ Factory<v8::BooleanObject>::New(bool value) {
   return v8::BooleanObject::New(value).As<v8::BooleanObject>();
 }
 
+//=== Context ==================================================================
+
+Factory<v8::Context>::return_t
+Factory<v8::Context>::New( v8::ExtensionConfiguration* extensions
+                         , v8::Handle<v8::ObjectTemplate> tmpl
+                         , v8::Handle<v8::Value> obj) {
+  v8::Persistent<v8::Context> ctx = v8::Context::New(extensions, tmpl, obj);
+  v8::Local<v8::Context> lctx = v8::Local<v8::Context>::New(ctx);
+  ctx.Dispose();
+  return lctx;
+}
+
 //=== Date =====================================================================
 
 Factory<v8::Date>::return_t

--- a/nan_new.h
+++ b/nan_new.h
@@ -52,6 +52,15 @@ struct Factory<v8::BooleanObject> : FactoryBase<v8::BooleanObject> {
 };
 
 template <>
+struct Factory<v8::Context> : FactoryBase<v8::Context> {
+  static inline
+  return_t
+  New( v8::ExtensionConfiguration* extensions = NULL
+     , v8::Handle<v8::ObjectTemplate> tmpl = v8::Handle<v8::ObjectTemplate>()
+     , v8::Handle<v8::Value> obj = v8::Handle<v8::Value>());
+};
+
+template <>
 struct Factory<v8::Date> : FactoryBase<v8::Date> {
   static inline return_t New(double value);
 };

--- a/test/cpp/nannew.cpp
+++ b/test/cpp/nannew.cpp
@@ -93,6 +93,23 @@ NAN_METHOD(testBooleanObject) {
 }
 #undef V
 
+NAN_METHOD(testContext) {
+  NanScope();
+  NanTap t(args[0]);
+
+  t.plan(4);
+  t.ok(_( assertType<Context>( NanNew<Context>())));
+  ExtensionConfiguration extensions(0, NULL);
+  t.ok(_( assertType<Context>( NanNew<Context>(&extensions))));
+  t.ok(_( assertType<Context>(
+          NanNew<Context>(&extensions, Handle<ObjectTemplate>()))));
+  t.ok(_( assertType<Context>(
+          NanNew<Context>(&extensions
+          , Handle<ObjectTemplate>(), Handle<Value>()))));
+
+  return_NanUndefined();
+}
+
 NAN_METHOD(testDate) {
   NanScope();
   NanTap t(args[0]);
@@ -372,6 +389,7 @@ void Init(Handle<Object> exports) {
   NAN_EXPORT(exports, testArray);
   NAN_EXPORT(exports, testBoolean);
   NAN_EXPORT(exports, testBooleanObject);
+  NAN_EXPORT(exports, testContext);
   NAN_EXPORT(exports, testDate);
   NAN_EXPORT(exports, testExternal);
   NAN_EXPORT(exports, testFunctionTemplate);

--- a/test/cpp/nannew.cpp
+++ b/test/cpp/nannew.cpp
@@ -139,8 +139,9 @@ NAN_METHOD(testFunctionTemplate) {
   NanScope();
   NanTap t(args[0]);
 
-  t.plan(3);
+  t.plan(4);
 
+  t.ok(_( assertType<FunctionTemplate>( NanNew<FunctionTemplate>())));
   t.ok(_( assertType<FunctionTemplate>(
           NanNew<FunctionTemplate>(testFunctionTemplate))));
   v8::Local<String> data = NanNew("plonk");


### PR DESCRIPTION
Added `NanNew<Context>` and deprecated `NanNewContextHandle`. Scheduled for 1.6.0.
R=@agnat