### PR TITLE
windows: Circumvent warning C4800

### DIFF
--- a/test/cpp/nannew.cpp
+++ b/test/cpp/nannew.cpp
@@ -323,14 +323,20 @@ NAN_METHOD(testRegression212) {
 
   typedef int  gint;
   typedef gint gboolean;
+#if defined(_MSC_VER)
+# pragma warning( disable : 4800 )
+#endif
   t.ok(_( assertType<Boolean>( NanNew<Boolean>(gboolean(23)))));
+#if defined(_MSC_VER)
+# pragma warning( default : 4800 )
+#endif
 
   return_NanUndefined();
 }
 
 /* Compile time regression test for https://github.com/rvagg/nan/issues/242
  * In the presence of overloaded functions NaN should be able to pick the one
- * matching NanFunctionCallback. 
+ * matching NanFunctionCallback.
  */
 void overloaded() {}
 NAN_METHOD(overloaded) {


### PR DESCRIPTION
msvc does not like imlpicit boolean conversion

Is this the right way to fix it?
What if I use an unsigned int?

Would it be better to do this?
```c++
template<>
inline typename NanIntern::Factory<v8::Boolean>::return_t
NanNew<v8::Boolean, A0>(A0 arg0) {
  return NanIntern::Factory<v8::Boolean>::New(arg0 != 0);
}
```
Should the above then be complemented with this?
```c++
template<>
inline typename NanIntern::Factory<v8::Boolean>::return_t
NanNew<v8::Boolean, bool>(A0 arg0) {
  return NanIntern::Factory<v8::Boolean>::New(arg0);
}
```

R=@agnat