### PR TITLE
fix a bug occurred the compilation error

### DIFF
--- a/nan.h
+++ b/nan.h
@@ -1847,7 +1847,7 @@ NAN_INLINE v8::Local<v8::Value> NanEncode(
 #if (NODE_MODULE_VERSION > 0x000B)
   return node::Encode(
       v8::Isolate::GetCurrent()
-    , buf, len
+    , (const char *)buf, len
     , static_cast<node::encoding>(encoding));
 #else
 # if  (NODE_MODULE_VERSION < 0x000B)

--- a/nan.h
+++ b/nan.h
@@ -1844,20 +1844,27 @@ namespace Nan {
 
 NAN_INLINE v8::Local<v8::Value> NanEncode(
     const void *buf, size_t len, enum Nan::Encoding encoding = Nan::BINARY) {
+#if (NODE_MODULE_VERSION >= 42)
+  return node::Encode(
+      v8::Isolate::GetCurrent()
+    , static_cast<const char *>(buf), len
+    , static_cast<node::encoding>(encoding));
+#else
 #if (NODE_MODULE_VERSION > 0x000B)
   return node::Encode(
       v8::Isolate::GetCurrent()
-    , (const char *)buf, len
+    , buf, len
     , static_cast<node::encoding>(encoding));
 #else
-# if  (NODE_MODULE_VERSION < 0x000B)
+#if (NODE_MODULE_VERSION < 0x000B)
   if (encoding == Nan::BUFFER) {
     assert(len <= node::Buffer::kMaxLength);
     return v8::Local<v8::Value>::New(node::Buffer::New(
         static_cast<char *>(const_cast<void *>(buf)), len)->handle_);
   }
-# endif
+#endif
   return node::Encode(buf, len, static_cast<node::encoding>(encoding));
+#endif
 #endif
 }
 


### PR DESCRIPTION
```
1.0.3/src/node.h:251:34: note: candidate function not viable: cannot convert argument of
      incomplete type 'const void *' to 'const char *'
NODE_EXTERN v8::Local<v8::Value> Encode(v8::Isolate* isolate,
                                 ^
```

https://github.com/rvagg/nan/issues/264