### PR TITLE
Test NanNew<Context> better.

### DIFF
--- a/test/cpp/nannew.cpp
+++ b/test/cpp/nannew.cpp
@@ -103,10 +103,13 @@ NAN_METHOD(testContext) {
   NanScope();
   NanTap t(args[0]);
 
-  t.plan(4);
+  t.plan(5);
   t.ok(_( assertType<Context>( NanNew<Context>())));
   ExtensionConfiguration extensions(0, NULL);
   t.ok(_( assertType<Context>( NanNew<Context>(&extensions))));
+  t.ok(_( assertType<Context>(
+          NanNew<Context>(reinterpret_cast<ExtensionConfiguration *>(NULL)
+          , Handle<ObjectTemplate>()))));
   t.ok(_( assertType<Context>(
           NanNew<Context>(&extensions, Handle<ObjectTemplate>()))));
   t.ok(_( assertType<Context>(


### PR DESCRIPTION
@agnat This fails. What is the correct fix? An overload?

```
../../nan_new.h: In instantiation of ‘typename NanIntern::Factory<T>::return_t NanNew(A0, A1) [with T = v8::Context; A0 = long int; A1 = v8::Handle<v8::ObjectTemplate>; typename NanIntern::Factory<T>::return_t = v8::Local<v8::Context>]’:
../cpp/nannew.cpp:110:8:   required from here
../../nan_new.h:215:47: error: invalid conversion from ‘long int’ to ‘v8::ExtensionConfiguration*’ [-fpermissive]
   return NanIntern::Factory<T>::New(arg0, arg1);
```