### PR TITLE
attempt to fix `NanNew<Integer>( sizeof(char) )`

### DIFF
--- a/nan_new.h
+++ b/nan_new.h
@@ -106,6 +106,7 @@ struct Factory<v8::NumberObject> : FactoryBase<v8::NumberObject> {
 template <typename T>
 struct IntegerFactory : FactoryBase<T> {
   typedef typename FactoryBase<T>::return_t return_t;
+  static inline return_t New(size_t value);
   static inline return_t New(int32_t value);
   static inline return_t New(uint32_t value);
 };
@@ -118,6 +119,7 @@ struct Factory<v8::Int32> : IntegerFactory<v8::Int32> {};
 
 template <>
 struct Factory<v8::Uint32> : FactoryBase<v8::Uint32> {
+  static inline return_t New(size_t value);
   static inline return_t New(int32_t value);
   static inline return_t New(uint32_t value);
 };

--- a/test/cpp/nannew.cpp
+++ b/test/cpp/nannew.cpp
@@ -182,13 +182,16 @@ NAN_METHOD(testNumber) {
 
   t.ok(_( NanNew<Int32>(5)->Value() == 5 ));
   t.ok(_( NanNew<Int32>(-42)->Value() == -42 ));
+  t.ok(_( NanNew<Int32>(sizeof(uint8_t))->Value() == 1 ));
   t.ok(_( assertType<Int32>( NanNew<Int32>(23) )));
 
   t.ok(_( NanNew<Uint32>(5u)->Value() == 5u ));
+  t.ok(_( NanNew<Uint32>(sizeof(uint8_t))->Value() == 1 ));
   t.ok(_( assertType<Uint32>( NanNew<Uint32>(23u) )));
 
   t.ok(_( NanNew<Integer>(5)->Value() == 5 ));
   t.ok(_( NanNew<Integer>(-1337)->Value() == -1337 ));
+  t.ok(_( NanNew<Integer>(sizeof(uint8_t))->Value() == 1 ));
   t.ok(_( assertType<Integer>( NanNew<Integer>(-42) )));
 
   t.ok(_( fabs(NanNew<Number>(M_PI)->Value() - M_PI) < epsilon));


### PR DESCRIPTION
I'm not sure if this is really the proper fix or not, but in previous versions of nan I have been able to do:

``` c++
size_t b = 1;
NanReturnValue(NanNew<Integer>(b));
```

But on 1.6.2 this no longer compiles :(

This seems to make it compile again, though I'm getting a compiler warning that I don't quite understand:

```
In file included from ../cpp/nannew.cpp:14:
In file included from ../../nan.h:80:
../../nan_new.h:109:26: warning: inline function 'NanIntern::IntegerFactory<v8::Integer>::New' is not defined [-Wundefined-inline]
  static inline return_t New(size_t value);
                         ^
../../nan_new.h:211:33: note: used here
  return NanIntern::Factory<T>::New(arg0);
                                ^
../../nan_new.h:109:26: warning: inline function 'NanIntern::IntegerFactory<v8::Int32>::New' is not defined [-Wundefined-inline]
  static inline return_t New(size_t value);
                         ^
../../nan_new.h:211:33: note: used here
  return NanIntern::Factory<T>::New(arg0);
                                ^
../../nan_new.h:122:26: warning: inline function 'NanIntern::Factory<v8::Uint32>::New' is not defined [-Wundefined-inline]
  static inline return_t New(size_t value);
                         ^
../../nan_new.h:211:33: note: used here
  return NanIntern::Factory<T>::New(arg0);
                                ^
3 warnings generated.
```

Hoping that we can get `size_t` support back so that I don't need to add a bunch of `static_cast<int32_t>(b)` casts to my modules. Cheers!