### PR TITLE
Allow the use of Isolated V8 methods for node-0.12

### DIFF
--- a/nan.h
+++ b/nan.h
@@ -173,7 +173,7 @@ NAN_INLINE v8::Local<T> _NanEnsureLocal(v8::Local<T> val) {
 }
 
 /* io.js 1.0  */
-#if NODE_MODULE_VERSION >= IOJS_1_0_MODULE_VERSION \
+#if NODE_MODULE_VERSION >= NODE_0_12_MODULE_VERSION \
  || NODE_VERSION_AT_LEAST(0, 11, 15)
   NAN_INLINE
   void NanSetCounterFunction(v8::CounterLookupCallback cb) {


### PR DESCRIPTION
I was trying to build the [atom/node-spellchecker](https://github.com/atom/node-spellchecker) for nw.js with nw-gyp and keep getting the same error:

```
▶ nw-gyp build
gyp info it worked if it ends with ok
gyp info using nw-gyp@0.12.4
gyp info using node@0.12.0 | darwin | x64
child_process: customFds option is deprecated, use stdio instead.
gyp info spawn make
gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
  CXX(target) Release/obj.target/spellchecker/src/main.o
In file included from ../src/main.cc:1:
../node_modules/nan/nan.h:207:13: error: no type named 'SetCounterFunction' in 'v8::V8'
    v8::V8::SetCounterFunction(cb);
    ~~~~~~~~^
../node_modules/nan/nan.h:212:13: error: no type named 'SetCreateHistogramFunction' in 'v8::V8'
    v8::V8::SetCreateHistogramFunction(cb);
    ~~~~~~~~^
../node_modules/nan/nan.h:217:13: error: no type named 'SetAddHistogramSampleFunction' in 'v8::V8'
    v8::V8::SetAddHistogramSampleFunction(cb);
    ~~~~~~~~^
../node_modules/nan/nan.h:221:12: error: no member named 'IdleNotification' in 'v8::V8'; did you mean 'NanIdleNotification'?
    return v8::V8::IdleNotification(idle_time_in_ms);
           ^~~~~~~~~~~~~~~~~~~~~~~~
           NanIdleNotification
../node_modules/nan/nan.h:220:19: note: 'NanIdleNotification' declared here
  NAN_INLINE bool NanIdleNotification(int idle_time_in_ms) {
                  ^
../node_modules/nan/nan.h:225:5: error: no member named 'LowMemoryNotification' in 'v8::V8'; did you mean 'NanLowMemoryNotification'?
    v8::V8::LowMemoryNotification();
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    NanLowMemoryNotification
../node_modules/nan/nan.h:224:19: note: 'NanLowMemoryNotification' declared here
  NAN_INLINE void NanLowMemoryNotification() {
                  ^
../node_modules/nan/nan.h:229:5: error: no member named 'ContextDisposedNotification' in 'v8::V8'; did you mean 'NanContextDisposedNotification'?
    v8::V8::ContextDisposedNotification();
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    NanContextDisposedNotification
../node_modules/nan/nan.h:228:19: note: 'NanContextDisposedNotification' declared here
  NAN_INLINE void NanContextDisposedNotification() {
                  ^
6 errors generated.
make: *** [Release/obj.target/spellchecker/src/main.o] Error 1
gyp ERR! build error
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/usr/local/lib/node_modules/nw-gyp/lib/build.js:267:23)
gyp ERR! stack     at ChildProcess.emit (events.js:110:17)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (child_process.js:1067:12)
gyp ERR! System Darwin 14.1.0
gyp ERR! command "node" "/usr/local/bin/nw-gyp" "build"
gyp ERR! cwd /Users/mob/Dev/node-spellchecker
gyp ERR! node -v v0.12.0
gyp ERR! nw-gyp -v v0.12.4
gyp ERR! not ok
```

After a lot of research I found that node-0.12 uses V8 version 3.28.73 which implement the method with Isolated (https://chromium.googlesource.com/v8/v8.git/+/3.28.73/src/api.cc#6692), and in the code those are available only for `NODE_MODULE_VERSION >= IOJS_1_0_MODULE_VERSION`.

After this change it worked, this is my first PR so any comments or another way to achieve the same are welcome.