### PR TITLE
Feature request: Adding comparison operators to NanCallback

### DIFF
--- a/nan.h
+++ b/nan.h
@@ -1393,6 +1393,17 @@ class NanCallback {
     NanDisposePersistent(handle);
   }
 
+  bool operator==(const NanCallback &other) const {
+    NanScope();
+    v8::Local<v8::Value> a = NanNew(handle)->Get(kCallbackIndex);
+    v8::Local<v8::Value> b = NanNew(other.handle)->Get(kCallbackIndex);
+    return a->StrictEquals(b);
+  }
+
+  bool operator!=(const NanCallback &other) const {
+    return !this->operator==(other);
+  }
+
   NAN_INLINE void SetFunction(const v8::Handle<v8::Function> &fn) {
     NanScope();
     NanNew(handle)->Set(kCallbackIndex, fn);

--- a/test/cpp/nancallback.cpp
+++ b/test/cpp/nancallback.cpp
@@ -24,6 +24,16 @@ NAN_METHOD(SpecificContext) {
   NanReturnUndefined();
 }
 
+NAN_METHOD(CompareCallbacks) {
+  NanScope();
+
+  NanCallback cb1(args[0].As<v8::Function>());
+  NanCallback cb2(args[1].As<v8::Function>());
+  NanCallback cb3(args[2].As<v8::Function>());
+
+  NanReturnValue(NanNew<v8::Boolean>(cb1 == cb2 && cb1 != cb3));
+}
+
 void Init (v8::Handle<v8::Object> target) {
   target->Set(
       NanNew<v8::String>("globalContext")
@@ -32,6 +42,10 @@ void Init (v8::Handle<v8::Object> target) {
   target->Set(
       NanNew<v8::String>("specificContext")
     , NanNew<v8::FunctionTemplate>(SpecificContext)->GetFunction()
+  );
+  target->Set(
+      NanNew<v8::String>("compareCallbacks")
+    , NanNew<v8::FunctionTemplate>(CompareCallbacks)->GetFunction()
   );
 }
 

--- a/test/js/nancallback-test.js
+++ b/test/js/nancallback-test.js
@@ -8,14 +8,23 @@
 
 const test     = require('tap').test
     , testRoot = require('path').resolve(__dirname, '..')
-    , bindings = require('bindings')({ module_root: testRoot, bindings: 'nancallback' });
+    , bindings = require('bindings')({ module_root: testRoot, bindings: 'nancallback' })
+    , round = Math.round;
 
 test('nancallback', function (t) {
-  t.plan(4)
+  t.plan(7)
 
   var persistent = bindings;
   t.type(persistent.globalContext, 'function');
   t.type(persistent.specificContext, 'function');
+  t.type(persistent.compareCallbacks, 'function');
   persistent.globalContext(function () { t.ok(true); });
   persistent.specificContext(function () { t.ok(true); });
+
+  var round2 = Math.round
+    , x = function(param) { return param + 1; }
+    , y = function(param) { return param + 2; }
+    , x2 = x;
+  t.ok(persistent.compareCallbacks(round, round2, Math.floor));
+  t.ok(persistent.compareCallbacks(x, x2, y));
 })


### PR DESCRIPTION
This simplifies comparison of `NanCallback`s constructed with the same `v8::Local<v8::Function>`-object (see the tests in `test/cpp/nancallback.cpp` for use-cases). What do you think about it?