### PR TITLE
Allow primitives with NanReturnValue

### DIFF
--- a/nan.h
+++ b/nan.h
@@ -174,7 +174,7 @@ NAN_INLINE v8::Local<T> _NanEnsureLocal(v8::Local<T> val) {
 
 /* io.js 1.0  */
 #if NODE_MODULE_VERSION >= IOJS_1_0_MODULE_VERSION \
- || NODE_VERSION_AT_LEAST(0, 11, 15)
+  || NODE_VERSION_AT_LEAST(0, 11, 15)
   NAN_INLINE
   void NanSetCounterFunction(v8::CounterLookupCallback cb) {
     v8::Isolate::GetCurrent()->SetCounterFunction(cb);
@@ -1475,7 +1475,6 @@ class NanCallback {
 #endif
   }
 };
-
 
 /* abstract */ class NanAsyncWorker {
  public:

--- a/nan.h
+++ b/nan.h
@@ -172,6 +172,11 @@ NAN_INLINE v8::Local<T> _NanEnsureLocal(v8::Local<T> val) {
   return val;
 }
 
+template<typename T>
+NAN_INLINE v8::Local<v8::Value> _NanEnsureLocal(T val) {
+  return NanNew(val);
+}
+
 /* io.js 1.0  */
 #if NODE_MODULE_VERSION >= IOJS_1_0_MODULE_VERSION \
   || NODE_VERSION_AT_LEAST(0, 11, 15)
@@ -303,7 +308,7 @@ NAN_INLINE v8::Local<T> _NanEnsureLocal(v8::Local<T> val) {
 # define NanEscapeScope(val) scope.Escape(_NanEnsureLocal(val))
 # define NanLocker() v8::Locker locker(v8::Isolate::GetCurrent())
 # define NanUnlocker() v8::Unlocker unlocker(v8::Isolate::GetCurrent())
-# define NanReturnValue(value) return args.GetReturnValue().Set(value)
+# define NanReturnValue(value) return args.GetReturnValue().Set(_NanEnsureLocal(value))
 # define NanReturnUndefined() return
 # define NanReturnHolder() NanReturnValue(args.Holder())
 # define NanReturnThis() NanReturnValue(args.This())
@@ -839,7 +844,7 @@ NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
 # define NanEscapeScope(val) scope.Close(val)
 # define NanLocker() v8::Locker locker
 # define NanUnlocker() v8::Unlocker unlocker
-# define NanReturnValue(value) return scope.Close(value)
+# define NanReturnValue(value) return scope.Close(_NanEnsureLocal(value))
 # define NanReturnHolder() NanReturnValue(args.Holder())
 # define NanReturnThis() NanReturnValue(args.This())
 # define NanReturnUndefined() return v8::Undefined()

--- a/test/cpp/nannew.cpp
+++ b/test/cpp/nannew.cpp
@@ -108,7 +108,7 @@ NAN_METHOD(testContext) {
   ExtensionConfiguration extensions(0, NULL);
   t.ok(_( assertType<Context>( NanNew<Context>(&extensions))));
   t.ok(_( assertType<Context>(
-          NanNew<Context>(reinterpret_cast<ExtensionConfiguration *>(NULL)
+          NanNew<Context>(static_cast<ExtensionConfiguration *>(NULL)
           , Handle<ObjectTemplate>()))));
   t.ok(_( assertType<Context>(
           NanNew<Context>(&extensions, Handle<ObjectTemplate>()))));

--- a/test/cpp/returnvalue.cpp
+++ b/test/cpp/returnvalue.cpp
@@ -17,10 +17,28 @@ NAN_METHOD(ReturnValue) {
   }
 }
 
+NAN_METHOD(ReturnPrimitive) {
+  NanScope();
+  NanReturnValue(true);
+}
+
+NAN_METHOD(ReturnString) {
+  NanScope();
+  NanReturnValue("yes, it works");
+}
+
 void Init (v8::Handle<v8::Object> target) {
   target->Set(
       NanNew<v8::String>("r")
     , NanNew<v8::FunctionTemplate>(ReturnValue)->GetFunction()
+  );
+  target->Set(
+      NanNew<v8::String>("p")
+    , NanNew<v8::FunctionTemplate>(ReturnPrimitive)->GetFunction()
+  );
+  target->Set(
+      NanNew<v8::String>("s")
+    , NanNew<v8::FunctionTemplate>(ReturnString)->GetFunction()
   );
 }
 

--- a/test/js/returnvalue-test.js
+++ b/test/js/returnvalue-test.js
@@ -11,8 +11,12 @@ const test     = require('tap').test
     , bindings = require('bindings')({ module_root: testRoot, bindings: 'returnvalue' });
 
 test('returnvalue', function (t) {
-  t.plan(3);
+  t.plan(7);
   t.type(bindings.r, 'function');
+  t.type(bindings.p, 'function');
+  t.type(bindings.s, 'function');
   t.equal(bindings.r('a string value'), 'a string value');
   t.equal(bindings.r(), 'default');
+  t.ok(bindings.p());
+  t.equal(bindings.s(), 'yes, it works');
 });


### PR DESCRIPTION
This should give some more convenience. Note that new v8 already allows returning primitives and silently wraps them in v8 types.