### PR TITLE
Ticket #306: Backport thread local storage

### DIFF
--- a/nan.h
+++ b/nan.h
@@ -153,7 +153,7 @@ inline void nauv_key_set(nauv_key_t* key, void* value) {
 
 #else
 
-#include <Windows.h>
+#include <windows.h>
 
 typedef struct {
   DWORD tls_index;

--- a/test/binding.gyp
+++ b/test/binding.gyp
@@ -96,4 +96,8 @@
         "target_name" : "nancallback"
       , "sources"     : [ "cpp/nancallback.cpp" ]
     }
+    , {
+        "target_name" : "threadlocal"
+      , "sources"     : [ "cpp/threadlocal.cpp" ]
+    }
 ]}

--- a/test/cpp/threadlocal.cpp
+++ b/test/cpp/threadlocal.cpp
@@ -1,0 +1,68 @@
+/*********************************************************************
+ * NAN - Native Abstractions for Node.js
+ *
+ * Copyright (c) 2015 NAN contributors
+ *
+ * MIT License <https://github.com/rvagg/nan/blob/master/LICENSE.md>
+ ********************************************************************/
+
+#include <nan.h>
+
+#define _(e) NAN_TEST_EXPRESSION(e)
+
+// Based on test-thread.c from libuv.
+
+class TlsTest : public NanAsyncWorker {
+public:
+  TlsTest(NanTap *t) : NanAsyncWorker(NULL), t(t), i(0) {
+    NanScope();
+    t->plan(7);
+    t->ok(_(0 == nauv_key_create(&tls_key)));
+    t->ok(_(NULL == nauv_key_get(&tls_key)));
+    nauv_key_set(&tls_key, this);
+    t->ok(_(this == nauv_key_get(&tls_key)));
+  }
+  void Execute() {
+    ok(_(NULL == nauv_key_get(&tls_key)));
+    nauv_key_set(&tls_key, &i);
+    ok(_(&i == nauv_key_get(&tls_key)));
+    nauv_key_set(&tls_key, NULL);
+    ok(_(NULL == nauv_key_get(&tls_key)));
+  }
+  void WorkComplete() {
+    NanScope();
+    for (unsigned j = 0; j < i; ++j)
+      t->ok(res[j].ok, res[j].msg);
+    nauv_key_delete(&tls_key);
+    t->ok(_(NULL == ErrorMessage()));
+    delete t;
+  }
+private:
+  nauv_key_t tls_key;
+
+  NanTap *t;
+  struct { bool ok; const char* msg; } res[3];
+  unsigned i;
+  void ok(bool isOk, const char *msg) {
+    assert(i < sizeof(res)/sizeof(res[0]));
+    res[i].ok = isOk;
+    res[i].msg = msg;
+    ++i;
+  }
+};
+
+NAN_METHOD(thread_local_storage) {
+  NanScope();
+  NanTap *t = new NanTap(args[0]);
+  NanAsyncQueueWorker(new TlsTest(t));
+  return_NanUndefined();
+}
+
+void Init(v8::Handle<v8::Object> exports) {
+  exports->Set(
+      NanNew<v8::String>("thread_local_storage")
+    , NanNew<v8::FunctionTemplate>(thread_local_storage)->GetFunction()
+  );
+}
+
+NODE_MODULE(threadlocal, Init)

--- a/test/js/threadlocal-test.js
+++ b/test/js/threadlocal-test.js
@@ -1,0 +1,13 @@
+/*********************************************************************
+ * NAN - Native Abstractions for Node.js
+ *
+ * Copyright (c) 2015 NAN contributors
+ *
+ * MIT License <https://github.com/rvagg/nan/blob/master/LICENSE.md>
+ ********************************************************************/
+
+const test     = require('tap').test
+    , testRoot = require('path').resolve(__dirname, '..')
+    , bindings = require('bindings')({ module_root: testRoot, bindings: 'threadlocal' });
+
+test('thread local storage', bindings.thread_local_storage);


### PR DESCRIPTION
This makes thread local storage available to older versions of libuv as well.  It is essentially a backport of libuv/libuv@5d2434bf71e47802841bad218d521fa254d1ca2d, written by Ben Noordhuis.  But the names were changed, and the functions were turned into inline functions to avoid having the same non-inline function in multiple translation units.  The test is a lot more node-based, even if the things to test more or less follow those tested in libuv.